### PR TITLE
refactor test harness, test a POST request with body

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -685,7 +685,7 @@ fn onReadBody(ctx: *ServerContext, client: *Client, cqe: io_uring_cqe) !void {
         return;
     }
 
-    // try processRequestWithBody(ctx, client);
+    try processRequestWithBody(ctx, client);
 }
 
 fn onOpenResponseFile(ctx: *ServerContext, client: *Client, cqe: io_uring_cqe) !void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -285,6 +285,9 @@ const ServerContext = struct {
     }
 
     pub fn maybeAccept(self: *Self, timeout: u63) !void {
+        if (!self.running.load(.SeqCst)) {
+            return;
+        }
         if (self.listener.accept_waiting or self.clients.list.items.len >= max_connections) {
             return;
         }

--- a/src/test.zig
+++ b/src/test.zig
@@ -8,9 +8,9 @@ const testing = std.testing;
 const time = std.time;
 
 const Atomic = std.atomic.Atomic;
+const assert = std.debug.assert;
 
 const curl = @import("curl.zig");
-
 const Server = @import("main.zig").Server;
 
 const port = 34450;
@@ -20,7 +20,6 @@ const TestHarness = struct {
     arena: heap.ArenaAllocator,
     socket: os.socket_t,
     server: Server,
-    running: Atomic(bool) = Atomic(bool).init(true),
 
     fn create(allocator: mem.Allocator) !*TestHarness {
         const socket = blk: {
@@ -56,17 +55,16 @@ const TestHarness = struct {
         res.server.thread = try std.Thread.spawn(
             .{},
             struct {
-                fn worker(running: *Atomic(bool), server: *Server) !void {
-                    while (running.load(.SeqCst)) {
-                        try server.ctx.maybeAccept(100 * time.ns_per_ms);
-                        try server.ctx.submit();
-                        try server.ctx.processCompletions();
+                fn worker(server: *Server) !void {
+                    while (server.ctx.running.load(.SeqCst)) {
+                        try server.ctx.maybeAccept(10 * time.ns_per_ms);
+                        const submitted = try server.ctx.submit(1);
+                        _ = try server.ctx.processCompletions(submitted);
                     }
-                    // There might be more completions not processed
-                    try server.ctx.processCompletions();
+                    try server.ctx.drain();
                 }
             }.worker,
-            .{ &res.running, &res.server },
+            .{&res.server},
         );
 
         return res;
@@ -74,7 +72,7 @@ const TestHarness = struct {
 
     fn deinit(self: *TestHarness) void {
         // Wait for the server to finish
-        self.running.store(false, .SeqCst);
+        self.server.ctx.running.store(false, .SeqCst);
         self.server.thread.join();
 
         // Clean up the server
@@ -86,28 +84,33 @@ const TestHarness = struct {
         self.root_allocator.destroy(self);
     }
 
-    fn do(self: *TestHarness, method: []const u8, path: []const u8) !curl.Response {
+    fn do(self: *TestHarness, method: []const u8, path: []const u8, body_opt: ?[]const u8) !curl.Response {
         var buf: [1024]u8 = undefined;
         const url = try fmt.bufPrintZ(&buf, "http://localhost:{d}{s}", .{
             port,
             path,
         });
 
-        return curl.do(self.root_allocator, method, url);
+        return curl.do(self.root_allocator, method, url, body_opt);
     }
 };
 
 test "GET 200 OK" {
-    var th = try TestHarness.create(testing.allocator);
-    defer th.deinit();
+    // Try to test multiple end conditions for the serving loop
 
-    var i: usize = 0;
+    var i: usize = 1;
     while (i < 20) : (i += 1) {
-        var resp = try th.do("GET", "/plaintext");
-        defer resp.deinit();
+        var th = try TestHarness.create(testing.allocator);
+        defer th.deinit();
 
-        try testing.expectEqual(@as(usize, 200), resp.response_code);
-        try testing.expectEqualStrings("Hello, World!", resp.data);
+        var j: usize = 0;
+        while (j < i) : (j += 1) {
+            var resp = try th.do("GET", "/plaintext", null);
+            defer resp.deinit();
+
+            try testing.expectEqual(@as(usize, 200), resp.response_code);
+            try testing.expectEqualStrings("Hello, World!", resp.data);
+        }
     }
 }
 
@@ -117,10 +120,29 @@ test "GET 404 Not Found" {
 
     var i: usize = 0;
     while (i < 20) : (i += 1) {
-        var resp = try th.do("GET", "/static/notfound.txt");
+        var resp = try th.do("GET", "/static/notfound.txt", null);
         defer resp.deinit();
 
         try testing.expectEqual(@as(usize, 404), resp.response_code);
         try testing.expectEqual(@as(usize, 0), resp.data.len);
+    }
+}
+
+test "POST 200 OK" {
+    var th = try TestHarness.create(testing.allocator);
+    defer th.deinit();
+
+    const body =
+        \\Perspiciatis eligendi aspernatur iste delectus et et quo repudiandae. Iusto repellat tempora nisi alias. Autem inventore rerum magnam sunt voluptatem aspernatur.
+        \\Consequuntur quae non fugit dignissimos at quis. Mollitia nisi minus voluptatem voluptatem sed sunt dolore. Expedita ullam ut ex voluptatem delectus. Fuga quos asperiores consequatur similique voluptatem provident vel. Repudiandae rerum quia dolorem totam.
+    ;
+
+    var i: usize = 0;
+    while (i < 2) : (i += 1) {
+        var resp = try th.do("POST", "/foobar", body);
+        defer resp.deinit();
+
+        try testing.expectEqual(@as(usize, 200), resp.response_code);
+        try testing.expectEqualStrings("Hello, World!", resp.data);
     }
 }


### PR DESCRIPTION
Keep track of pending SQEs, add a `drain` method which must be called to correctly finish processing when shutting down.

Modify curl to optionally pass a body in the request.

Add a test for a POST request with a body.