### PR TITLE
Register response files

### DIFF
--- a/src/io.zig
+++ b/src/io.zig
@@ -11,6 +11,11 @@ const logger = std.log.scoped(.io_helpers);
 // TODO(vincent): make this dynamic
 const max_connections = 128;
 
+pub const RegisteredFile = struct {
+    fd: os.fd_t,
+    size: u64,
+};
+
 /// Manages a set of registered file descriptors.
 /// The set size is fixed at compile time.
 ///


### PR DESCRIPTION
Register every response file using `IORING_REGISTER_FILES`.
This is very barebones and not quite safe to use since there's no way to unregister a response file and the map will keep growing.

This has significant performance benefits, here's a benchmark:
`master` branch:
```
$ hyperfine 'taskset -c 1 oha -n 100000 -c 1 --no-tui "http://localhost:3405/static/foobar.txt"'
Benchmark 1: taskset -c 1 oha -n 100000 -c 1 --no-tui "http://localhost:3405/static/foobar.txt"
  Time (mean ± σ):      3.861 s ±  0.438 s    [User: 0.541 s, System: 0.759 s]
  Range (min … max):    2.921 s …  4.355 s    10 runs
```
this branch:
```
$ hyperfine 'taskset -c 1 oha -n 100000 -c 1 --no-tui "http://localhost:3405/static/foobar.txt"'
Benchmark 1: taskset -c 1 oha -n 100000 -c 1 --no-tui "http://localhost:3405/static/foobar.txt"
  Time (mean ± σ):      2.315 s ±  0.459 s    [User: 0.481 s, System: 0.655 s]
  Range (min … max):    1.853 s …  2.896 s    10 runs
```